### PR TITLE
update to new edge_tpu 1.9.2

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-cd /usr/src/app/python-tflite-source/edgetpu
+cd /usr/src/app/
 
 # Run an image classification sample
-python3 demo/classify_image.py \
---model test_data/mobilenet_v2_1.0_224_inat_bird_quant_edgetpu.tflite \
---label test_data/inat_bird_labels.txt \
---image test_data/parrot.jpg
+python3 /usr/local/lib/python3.5/dist-packages/edgetpu/demo/classify_image.py \
+--model mobilenet_v2_1.0_224_inat_bird_quant_edgetpu.tflite \
+--label inat_bird_labels.txt \
+--image parrot.jpg
 
 sleep infinity


### PR DESCRIPTION
They changed the getting started, redid the install script and split out the demos, etc. So this PR fixes those things so that the demo works with the new 1.9.2 edge tpu wheel.